### PR TITLE
Check `status.success?` instead of stderr

### DIFF
--- a/lib/carrierwave/audio_waveform/waveform_data.rb
+++ b/lib/carrierwave/audio_waveform/waveform_data.rb
@@ -58,9 +58,7 @@ module CarrierWave
 
           @log.timed("\nGenerating...") do
             stdout_str, stderr_str, status = self.generate_waveform_data(source, options)
-            if stderr_str.present? && !stderr_str.include?("Recoverable")
-              raise RuntimeError.new(stderr_str)
-            end
+            raise RuntimeError.new(stderr_str) unless status.success?
           end
 
           if source != old_source && options[:convert_to_extension_before_processing]


### PR DESCRIPTION
This cropped up when I was setting up a littler dockerized version of the api. When using `docker-compose` it allocates a pseudo-tty and maps stderr and stdout to that same pseudo-tty, so `audiowaveform`'s progress output was causing Ruby to think it failed.

I think i can make it work by preventing the default pseudo-tty from being allocated in the compose file, but did confirm that `audiowaveform` correctly returns a non-zero status code when it fails, so this felt like a good change unless `audiowaveform` returns a non-zero exit code when it has a recoverable error?